### PR TITLE
H5 context management

### DIFF
--- a/src/fibsem_tools/io/h5.py
+++ b/src/fibsem_tools/io/h5.py
@@ -5,8 +5,6 @@ import warnings
 
 Pathlike = Union[str, Path]
 
-MPI = h5py.h5.get_config().mpi
-
 H5_ACCESS_MODES = ("r", "r+", "w", "w-", "x", "a")
 
 H5_DATASET_KWDS = ("name",

--- a/tests/test_h5.py
+++ b/tests/test_h5.py
@@ -1,0 +1,13 @@
+from h5py._hl.dataset import make_new_dset
+from fibsem_tools.io.h5 import partition_h5_kwargs
+from inspect import signature, Parameter
+
+def test_kwarg_partition():
+    dataset_creation_sig = signature(make_new_dset)
+    dataset_kwargs = {k: None for k,v in filter(lambda p: p[1].default is not Parameter.empty, dataset_creation_sig.parameters.items())}
+    file_kwargs = {'foo': None, 'bar': None}
+    file_kwargs_out, dataset_kwargs_out = partition_h5_kwargs(**dataset_kwargs, **file_kwargs)
+    assert file_kwargs == file_kwargs_out
+    assert dataset_kwargs == dataset_kwargs_out
+
+         

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -110,15 +110,21 @@ def test_access_array_h5():
     data = np.random.randint(0, 255, size=(10, 10, 10), dtype="uint8")
     attrs = {"resolution": "1000"}
     with tempfile.TemporaryFile(suffix=".h5") as store:
-        arr = access_h5(store, key, data=data, attrs=attrs, mode="w")
-        assert dict(arr.attrs) == attrs
-        assert np.array_equal(arr[:], data)
-        arr.file.close()
+        with access_h5(store, key, data=data, attrs=attrs, mode="w") as arr1:
+            assert dict(arr1.attrs) == attrs
+            assert np.array_equal(arr1[:], data)
 
-        arr2 = access_h5(store, key, mode="r")
-        assert dict(arr2.attrs) == attrs
-        assert np.array_equal(arr2[:], data)
-        arr2.file.close()
+        with access_h5(store, key, mode="r") as arr2:
+            assert dict(arr2.attrs) == attrs
+            assert np.array_equal(arr2[:], data)
+
+
+        with access_h5(store, key, mode='r') as arr3:
+            h5d = arr3.file[key]
+            assert h5d.shape == arr3.shape
+            assert h5d.attrs == arr3.attrs
+            assert h5d.chunks == arr3.chunks
+            assert h5d.compression == arr3.compression
 
 
 def test_access_group_h5():
@@ -126,13 +132,15 @@ def test_access_group_h5():
     attrs = {"resolution": "1000"}
 
     with tempfile.TemporaryFile(suffix=".h5") as store:
-        grp = access_h5(store, key, attrs=attrs, mode="w")
-        assert dict(grp.attrs) == attrs
-        grp.file.close()
+        with access_h5(store, key, attrs=attrs, mode="w") as grp1:
+            assert dict(grp1.attrs) == attrs
 
-        grp2 = access_h5(store, key, mode="r")
-        assert dict(grp2.attrs) == attrs
-        grp2.file.close()
+        with access_h5(store, key, mode="r") as grp2:
+            assert dict(grp2.attrs) == attrs
+
+        with access_h5(store, key, mode="r") as grp3:
+            h5g = grp3.file[key]
+            assert h5g.attrs == grp3.attrs
 
 
 def test_list_files():


### PR DESCRIPTION
- extends `h5py.Dataset` and `h5py.Group` to have `__enter__` and `__exit__` methods, where `__exit__` closes the file.
- use context-managed datasets and groups in tests
- add a test for the h5 kwarg partitioning 
- (untested) `access_h5` can optionally take an `h5py.File` instance as the first argument