### PR TITLE
Add optional value for num_voxels per label

### DIFF
--- a/src/fibsem_tools/metadata/groundtruth.py
+++ b/src/fibsem_tools/metadata/groundtruth.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 
 class InstanceName(BaseModel):
@@ -16,6 +16,7 @@ class Label(BaseModel):
     value: int
     name: InstanceName
     annotationState: AnnotationState
+    num_voxels: Optional[int]
 
 
 class LabelList(BaseModel):

--- a/src/fibsem_tools/metadata/groundtruth.py
+++ b/src/fibsem_tools/metadata/groundtruth.py
@@ -16,7 +16,7 @@ class Label(BaseModel):
     value: int
     name: InstanceName
     annotationState: AnnotationState
-    num_voxels: Optional[int]
+    count: Optional[int]
 
 
 class LabelList(BaseModel):


### PR DESCRIPTION
It would be nice to keep track of the number of annotated voxels per class per crop. With so many crops it can be time consuming to loop through and count voxels.