### PR TITLE
Add support for specifying semantic vs instance labels

### DIFF
--- a/src/fibsem_tools/metadata/groundtruth.py
+++ b/src/fibsem_tools/metadata/groundtruth.py
@@ -1,5 +1,11 @@
 from pydantic import BaseModel
 from typing import List
+from enum import Enum
+
+
+class AnnotationType(Enum):
+    semantic: "semantic"
+    instance: "instance"
 
 
 class InstanceName(BaseModel):
@@ -20,6 +26,7 @@ class Label(BaseModel):
 
 class LabelList(BaseModel):
     labels: List[Label]
+    annotation_type: AnnotationType = AnnotationType.semantic
 
 
 classNameDict = {


### PR DESCRIPTION
We have a few crops that are annotated as individual instances given unique ids. We should support this in our metadata.
I think its sufficient if we just have an enum defining the annotation type.

The meaning of the labels list changes depending on the annotation type.
1) If semantic, then I expect any voxel to be either 0 (unannotated) or one of the provided (`present + annotated`) labels.
2) If instance, than each voxel can be any uint{16,32,64...}, and each voxel belongs to one of the semantic classes defined in the labels list. I.e. mito instance segmentations would come with a labels list with [mito membrane, mito lumen, mito dna] all `present + annotated`. Everything else would be either `present + not annotated` or `not present + not annotated`.