### PR TITLE
chunked array ops API changes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -451,20 +451,21 @@ toml = ["tomli"]
 
 [[package]]
 name = "dask"
-version = "2023.3.1"
+version = "2023.3.2"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "dask-2023.3.1-py3-none-any.whl", hash = "sha256:4a83c05760aedb7deeee8c16d24479292635a1ded6c3f803bf6c3d94ec9e7d20"},
-    {file = "dask-2023.3.1.tar.gz", hash = "sha256:62d334012d7cd814186931ea83ebf1a6231c2af4260ad204dc78080a55947c17"},
+    {file = "dask-2023.3.2-py3-none-any.whl", hash = "sha256:5e64763d62feb18afd3ad66f364e0b4f456f7ac92e894fcc87950af75029ecdf"},
+    {file = "dask-2023.3.2.tar.gz", hash = "sha256:51009e92ba9a280bd417633d1ae84f3ed23a8940f0a19594a4b7797ef226fff4"},
 ]
 
 [package.dependencies]
 click = ">=7.0"
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
+importlib-metadata = ">=4.13.0"
 packaging = ">=20.0"
 partd = ">=1.2.0"
 pyyaml = ">=5.3.1"
@@ -472,10 +473,10 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.21)"]
-complete = ["bokeh (>=2.4.2,<3)", "distributed (==2023.3.1)", "jinja2 (>=2.10.3)", "lz4 (>=4.3.2)", "numpy (>=1.21)", "pandas (>=1.3)", "pyarrow (>=7.0)"]
+complete = ["bokeh (>=2.4.2,<3)", "distributed (==2023.3.2)", "jinja2 (>=2.10.3)", "lz4 (>=4.3.2)", "numpy (>=1.21)", "pandas (>=1.3)", "pyarrow (>=7.0)"]
 dataframe = ["numpy (>=1.21)", "pandas (>=1.3)"]
 diagnostics = ["bokeh (>=2.4.2,<3)", "jinja2 (>=2.10.3)"]
-distributed = ["distributed (==2023.3.1)"]
+distributed = ["distributed (==2023.3.2)"]
 test = ["pandas[test]", "pre-commit", "pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 [[package]]
@@ -492,20 +493,20 @@ files = [
 
 [[package]]
 name = "distributed"
-version = "2023.3.1"
+version = "2023.3.2"
 description = "Distributed scheduler for Dask"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "distributed-2023.3.1-py3-none-any.whl", hash = "sha256:542f691b6871eb9d3909e1f8eb4c274f09c69b89f07ff5a598de38a60237f162"},
-    {file = "distributed-2023.3.1.tar.gz", hash = "sha256:2551809869cd72d9957a10e1a6e5358371db31765ae6b1871541a0b7ce32090c"},
+    {file = "distributed-2023.3.2-py3-none-any.whl", hash = "sha256:43b74f08ea4ea0696ae8d2f1ea53adcda998a2a159bd34dffd42e4e678ff5f8a"},
+    {file = "distributed-2023.3.2.tar.gz", hash = "sha256:3f0b4ce73289583a27376672f67895e041c71d9a6e901b4f4cc4a95dd81ec349"},
 ]
 
 [package.dependencies]
 click = ">=8.0"
 cloudpickle = ">=1.5.0"
-dask = "2023.3.1"
+dask = "2023.3.2"
 jinja2 = ">=2.10.3"
 locket = ">=1.0.0"
 msgpack = ">=1.0.0"
@@ -753,6 +754,26 @@ files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
+
+[[package]]
+name = "importlib-metadata"
+version = "6.1.0"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "importlib_metadata-6.1.0-py3-none-any.whl", hash = "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"},
+    {file = "importlib_metadata-6.1.0.tar.gz", hash = "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -2073,7 +2094,23 @@ files = [
 [package.dependencies]
 heapdict = "*"
 
+[[package]]
+name = "zipp"
+version = "3.15.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
+    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8a4be2de6248c7ee739ec1efc7524e6a476eab18bd19d9026f39d98eb1b67737"
+content-hash = "190136757e3ae83835d339d3cef21477d7319fa894ff066ab66475983e89bd9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ xarray-multiscale = "^2.0.0"
 tifffile = "^2023.2.28"
 pydantic-ome-ngff = "^0.2.0"
 click = "^8.1.3"
+dask = "^2023.3.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/fibsem_tools/io/core.py
+++ b/src/fibsem_tools/io/core.py
@@ -252,7 +252,7 @@ def create_group(
     group_mode: AccessMode = "w-",
     array_mode: AccessMode = "w-",
     **array_kwargs,
-) -> Tuple[str, Tuple[str, ...]]:
+) -> zarr.Group:
 
     _arrays = tuple(a for a in arrays)
     _array_paths = tuple(p for p in array_paths)
@@ -270,7 +270,7 @@ def create_group(
             """
         )
 
-    access(group_url, mode=group_mode, attrs=group_attrs)
+    group = access(group_url, mode=group_mode, attrs=group_attrs)
     a_urls = [os.path.join(group_url, name) for name in _array_paths]
 
     if array_attrs is None:
@@ -290,4 +290,4 @@ def create_group(
             **array_kwargs,
         )
 
-    return group_url, a_urls
+    return group

--- a/src/fibsem_tools/io/core.py
+++ b/src/fibsem_tools/io/core.py
@@ -20,7 +20,6 @@ import mrcfile
 import zarr
 from numpy.typing import NDArray
 from xarray import DataArray
-import fsspec
 
 from fibsem_tools.metadata.transform import STTransform
 from fibsem_tools.io.util import Attrs, PathLike
@@ -271,18 +270,16 @@ def create_group(
             """
         )
 
-    protocol = fsspec.get_mapper(path).fs.protocol
-    protocol_prefix = protocol + "://"
-    group = access(group_url, mode=group_mode, attrs=group_attrs)
+    access(group_url, mode=group_mode, attrs=group_attrs)
+    a_urls = [os.path.join(group_url, name) for name in _array_paths]
 
     if array_attrs is None:
         _array_attrs: Tuple[Attrs, ...] = ({},) * len(_arrays)
     else:
         _array_attrs = array_attrs
 
-    for idx, vals in enumerate(zip(_arrays, _array_paths, _array_attrs)):
-        array, name, attrs = vals
-        path = protocol_prefix + os.path.join(group.store.path, group.path, name)
+    for idx, vals in enumerate(zip(_arrays, a_urls, _array_attrs)):
+        array, path, attrs = vals
         access(
             path=path,
             mode=array_mode,
@@ -292,7 +289,5 @@ def create_group(
             attrs=attrs,
             **array_kwargs,
         )
-    g_url = protocol_prefix + os.path.join(group.store.path, group.path)
-    a_urls = [os.path.join(g_url, name) for name in _array_paths]
 
-    return g_url, a_urls
+    return group_url, a_urls

--- a/src/fibsem_tools/io/dask.py
+++ b/src/fibsem_tools/io/dask.py
@@ -322,6 +322,10 @@ def copy_array(
     write_empty_chunks: bool, defaults to False
         Whether empty chunks should be written to storage. Defaults to False.
 
+    Returns
+    -------
+
+    A dask bag which, when computed, will copy data from source to dest.
 
     """
     if isinstance(source, PathLike):

--- a/src/fibsem_tools/io/dask.py
+++ b/src/fibsem_tools/io/dask.py
@@ -7,6 +7,7 @@ import dask.array as da
 from dask.bag import from_sequence
 import distributed
 import numpy as np
+
 from aiohttp import ServerDisconnectedError
 from dask.array.core import (
     slices_from_chunks,
@@ -288,33 +289,67 @@ def copy_from_slices(slices, source_array, dest_array):
 
 
 def copy_array(
-    source_url: PathLike,
-    dest_url: PathLike,
-    read_chunks: Tuple[int, ...],
+    source: Union[PathLike, NDArray],
+    dest: Union[PathLike, NDArray],
+    chunksize: Union[str, Tuple[int, ...]] = "100 MB",
     write_empty_chunks: bool = False,
     npartitions: int = 10000,
     randomize: bool = True,
 ):
     """
-    Copy data from one chunked array to another
-    """
+    Use Dask to copy data from one chunked array to another.
 
-    source_arr = read(source_url)
-    dest_arr = access(dest_url, mode="a", write_empty_chunks=write_empty_chunks)
+    Parameters
+    ----------
+
+    source: string, Pathlib.Path, array-like
+        The source of the data to be copied. If this argument is a path or string,
+        it is assumed to be url pointing to a resource that can be accessed via
+        `fibsem_tools.io.core.read`. Otherwise, it is assumed to be a chunked
+        array-like.
+
+    dest: string, Pathlib.Path, array-like.
+        The destination for the data to be copied. If this argument is a path or string,
+        it is assumed to be url pointing to a resource that can be accessed via
+        `fibsem_tools.io.core.access`. Otherwise, it is assumed to be a chunked
+        array-like that supports writing / appending.
+
+    chunks: tuple of ints or str
+        The chunk size used for reading from the source data. If a string is given,
+        it is assumed that this is a target size in bytes, and a chunk size will be
+        chosen automatically to not exceed this size.
+
+    write_empty_chunks: bool, defaults to False
+        Whether empty chunks should be written to storage. Defaults to False.
+
+
+    """
+    if isinstance(source, PathLike):
+        source_arr = read(source)
+    else:
+        source_arr = source
+
+    if isinstance(dest, PathLike):
+        dest_arr = access(dest, mode="a", write_empty_chunks=write_empty_chunks)
+    else:
+        dest_arr = dest
 
     # assume we are given a size in bytes
-    if isinstance(read_chunks, str):
-        chunk_size_limit_bytes = parse_bytes(read_chunks)
+    if isinstance(chunksize, str):
+        chunk_size_limit_bytes = parse_bytes(chunksize)
 
-        read_chunks = autoscale_chunk_shape(
-            dest_arr.chunks, chunk_size_limit_bytes, dest_arr.dtype, dest_arr.shape
+        chunksize = autoscale_chunk_shape(
+            chunk_shape=dest_arr.chunks,
+            array_shape=dest_arr.shape,
+            size_limit=chunk_size_limit_bytes,
+            dtype=dest_arr.dtype,
         )
 
     assert source_arr.shape == dest_arr.shape
     assert source_arr.dtype == dest_arr.dtype
-    assert are_chunks_aligned(read_chunks, dest_arr.chunks)
+    assert are_chunks_aligned(chunksize, dest_arr.chunks)
 
-    chunks_normalized = normalize_chunks_dask(read_chunks, shape=dest_arr.shape)
+    chunks_normalized = normalize_chunks_dask(chunksize, shape=dest_arr.shape)
     slices = slices_from_chunks(chunks_normalized)
 
     # randomization to ensure that we don't create prefix hotspots when writing to

--- a/src/fibsem_tools/io/dask.py
+++ b/src/fibsem_tools/io/dask.py
@@ -314,7 +314,7 @@ def copy_array(
         `fibsem_tools.io.core.access`. Otherwise, it is assumed to be a chunked
         array-like that supports writing / appending.
 
-    chunks: tuple of ints or str
+    chunksize: tuple of ints or str
         The chunk size used for reading from the source data. If a string is given,
         it is assumed that this is a target size in bytes, and a chunk size will be
         chosen automatically to not exceed this size.

--- a/src/fibsem_tools/io/zarr.py
+++ b/src/fibsem_tools/io/zarr.py
@@ -34,7 +34,7 @@ DEFAULT_ZARR_STORE = FSStore
 logger = logging.getLogger(__name__)
 
 
-def get_arrays(obj: Any) -> Tuple[zarr.core.Array]:
+def get_arrays(obj: Any) -> Tuple[zarr.Array]:
     result = ()
     if isinstance(obj, zarr.core.Array):
         result = (obj,)
@@ -45,15 +45,13 @@ def get_arrays(obj: Any) -> Tuple[zarr.core.Array]:
     return result
 
 
-def delete_zbranch(
-    branch: Union[zarr.hierarchy.Group, zarr.core.Array], compute: bool = True
-):
+def delete_zbranch(branch: Union[zarr.Group, zarr.Array], compute: bool = True):
     """
     Delete a branch (group or array) from a zarr container
     """
-    if isinstance(branch, zarr.hierarchy.Group):
+    if isinstance(branch, zarr.Group):
         return delete_zgroup(branch, compute=compute)
-    elif isinstance(branch, zarr.core.Array):
+    elif isinstance(branch, zarr.Array):
         return delete_zarray(branch, compute=compute)
     else:
         raise TypeError(
@@ -64,7 +62,7 @@ def delete_zbranch(
         )
 
 
-def delete_zgroup(zgroup: zarr.hierarchy.Group, compute: bool = True):
+def delete_zgroup(zgroup: zarr.Group, compute: bool = True):
     """
     Delete all arrays in a zarr group
     """
@@ -82,12 +80,12 @@ def delete_zgroup(zgroup: zarr.hierarchy.Group, compute: bool = True):
         return to_delete
 
 
-def delete_zarray(arr: zarr.core.Array, compute: bool = True):
+def delete_zarray(arr: zarr.Array, compute: bool = True):
     """
     Delete all the chunks in a zarr array.
     """
 
-    if not isinstance(arr, zarr.core.Array):
+    if not isinstance(arr, zarr.Array):
         raise TypeError(
             f"Cannot use the delete_zarray function on object of type {type(arr)}"
         )
@@ -148,6 +146,25 @@ def zarr_array_from_dask(arr: Any) -> Any:
     """
     keys = tuple(arr.dask.keys())
     return arr.dask[keys[-1]]
+
+
+def get_url(node: Union[zarr.Group, zarr.Array]):
+    store = node.store
+    if hasattr(store, "path"):
+        if hasattr(store, "fs"):
+            if isinstance(store.fs.protocol, list):
+                protocol = store.fs.protocol[0]
+            else:
+                protocol = store.fs.protocol
+        else:
+            protocol = "file"
+        return f"{protocol}://{os.path.join(node.store.path, node.path)}"
+    else:
+        raise ValueError(
+            f"""
+        The store associated with this object has type {type(store)}, which 
+        cannot be resolved to a path"""
+        )
 
 
 def access_zarr(store: PathLike, path: PathLike, **kwargs) -> Any:

--- a/src/fibsem_tools/io/zarr.py
+++ b/src/fibsem_tools/io/zarr.py
@@ -163,7 +163,7 @@ def get_url(node: Union[zarr.Group, zarr.Array]):
         raise ValueError(
             f"""
         The store associated with this object has type {type(store)}, which 
-        cannot be resolved to a path"""
+        cannot be resolved to a url"""
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import tempfile
+import shutil
+import pytest
+import atexit
+
+
+@pytest.fixture
+def temp_dir():
+    path = tempfile.mkdtemp()
+    atexit.register(shutil.rmtree, path)
+    return path
+
+
+@pytest.fixture
+def temp_zarr():
+    path = tempfile.mkdtemp(suffix=".zarr")
+    atexit.register(shutil.rmtree, path)
+    return path
+
+
+@pytest.fixture
+def temp_n5():
+    path = tempfile.mkdtemp(suffix=".n5")
+    atexit.register(shutil.rmtree, path)
+    return path

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -43,7 +43,7 @@ def test_multiscale_storage(temp_zarr, metadata_types: Tuple[str, ...]):
 
     chunks = ((8, 8, 8), (8, 8, 8))
     multi = [m.chunk(c) for m, c in zip(multi, chunks)]
-    group_url, array_urls = multiscale_group(
+    group = multiscale_group(
         temp_zarr,
         multi,
         array_paths=array_paths,
@@ -52,7 +52,8 @@ def test_multiscale_storage(temp_zarr, metadata_types: Tuple[str, ...]):
         compressor=GZip(-1),
     )
 
+    array_urls = [f"{temp_zarr}/{ap}" for ap in array_paths]
     da.compute(store_blocks(multi, [access(a_url, mode="a") for a_url in array_urls]))
 
-    assert dict(read(group_url).attrs) == g_meta
+    assert dict(group.attrs) == g_meta
     assert tuple(read(a).chunks for a in array_urls) == chunks

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -1,6 +1,3 @@
-import atexit
-import shutil
-import tempfile
 from typing import Tuple
 import pytest
 import dask.array as da
@@ -18,11 +15,7 @@ from fibsem_tools.io.multiscale import (
     "metadata_types",
     [("ome-ngff@0.4",), ("neuroglancer",), ("ome-ngff",), ("ome-ngff", "neuroglancer")],
 )
-def test_multiscale_storage(metadata_types: Tuple[str, ...]):
-
-    store = tempfile.mkdtemp(suffix=".zarr")
-    atexit.register(shutil.rmtree, store)
-
+def test_multiscale_storage(temp_zarr, metadata_types: Tuple[str, ...]):
     data = da.random.randint(0, 8, (16, 16, 16), chunks=(8, 8, 8), dtype="uint8")
     coords = [
         DataArray(
@@ -51,7 +44,7 @@ def test_multiscale_storage(metadata_types: Tuple[str, ...]):
     chunks = ((8, 8, 8), (8, 8, 8))
     multi = [m.chunk(c) for m, c in zip(multi, chunks)]
     group_url, array_urls = multiscale_group(
-        store,
+        temp_zarr,
         multi,
         array_paths=array_paths,
         metadata_types=metadata_types,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -176,7 +176,7 @@ def test_group_initialization():
     a_attrs = {"foo": {"a": 10}, "bar": {"b": 15}}
     g_attrs = {"bla": "bla"}
     chunks = ((2,), (2,))
-    group_path, _ = create_group(
+    group = create_group(
         store_path,
         data.values(),
         data.keys(),
@@ -184,7 +184,6 @@ def test_group_initialization():
         group_attrs=g_attrs,
         array_attrs=a_attrs.values(),
     )
-    group = read(group_path)
     assert g_attrs == dict(group.attrs)
     for d in data:
         assert data[d].shape == group[d].shape

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -1,0 +1,11 @@
+from zarr.storage import FSStore
+import zarr
+import numpy as np
+from fibsem_tools.io.zarr import get_url
+
+
+def test_url(temp_zarr):
+    store = FSStore(temp_zarr)
+    group = zarr.group(store)
+    arr = group.create_dataset(name="foo", data=np.arange(10))
+    assert get_url(arr) == f"file://{store.path}/foo"


### PR DESCRIPTION
- instead of returning a tuple of `[string, tuple[string, ...]]`, create_group now 
returns the group itself. 
- added `get_url` function for resolving a zarr group / array to a url
- the type signature of the parameters of `copy_array` was widened to support taking chunked arrays as well as pathlikes for the source and dest arguments.
- added disposable directories as test fixtures