### PR TITLE
old cosem metadata

### DIFF
--- a/src/fibsem_tools/metadata/cosem.py
+++ b/src/fibsem_tools/metadata/cosem.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 from pydantic import BaseModel
 from xarray import DataArray
@@ -6,9 +6,14 @@ from xarray import DataArray
 from fibsem_tools.metadata.transform import STTransform
 
 
+class ScaleMetaV1(BaseModel):
+    path: str
+    transform: STTransform
+
+
 class MultiscaleMetaV1(BaseModel):
     name: Optional[str]
-    datasets: Sequence[STTransform]
+    datasets: Sequence[ScaleMetaV1]
 
 
 class MultiscaleMetaV2(BaseModel):
@@ -16,19 +21,19 @@ class MultiscaleMetaV2(BaseModel):
     datasets: Sequence[str]
 
 
-class COSEMGroupMetadata(BaseModel):
+class COSEMGroupMetadataV1(BaseModel):
     """
     Multiscale metadata used by COSEM for multiscale datasets saved in N5/Zarr groups.
     """
 
-    multiscales: Union[Sequence[MultiscaleMetaV2], Sequence[MultiscaleMetaV1]]
+    multiscales: Sequence[MultiscaleMetaV1]
 
     @classmethod
     def fromDataArrays(
         cls,
         arrays: Sequence[DataArray],
+        paths: Sequence[str],
         name: Optional[str] = None,
-        paths: Optional[Sequence[str]] = None,
     ):
         """
         Generate multiscale metadata from a list or tuple of DataArrays.
@@ -36,34 +41,81 @@ class COSEMGroupMetadata(BaseModel):
         Parameters
         ----------
 
-        dataarrays : list or tuple of xarray.DataArray
+        arrays : list or tuple of xarray.DataArray
             The collection of arrays from which to generate multiscale metadata. These
             arrays are assumed to share the same `dims` attributes, albeit with varying
             `coords`.
 
-        name : str, optional
-            The name for the multiresolution collection
-
         paths : list or tuple of str or None, default=None
             The name on the storage backend for each of the arrays in the multiscale
             collection.
-            If None, the `name` attribute of each array in `dataarrays` will be used.
 
-        Returns an instance of COSEMGroupMetadata
+        name : str, optional
+            The name for the multiresolution collection
+
+
+        Returns an instance of COSEMGroupMetadataV1
         -------
 
         COSEMGroupMetadata
         """
 
-        if paths is None:
-            _paths: Sequence[str] = [str(d.name) for d in arrays]
-        else:
-            _paths = paths
+        multiscales = [
+            MultiscaleMetaV1(
+                name=name,
+                datasets=[
+                    ScaleMetaV1(
+                        path=path, transform=STTransform.fromDataArray(array=arr)
+                    )
+                    for path, arr in zip(paths, arrays)
+                ],
+            )
+        ]
+        return cls(name=name, multiscales=multiscales, paths=paths)
+
+
+class COSEMGroupMetadataV2(BaseModel):
+    """
+    Multiscale metadata used by COSEM for multiscale datasets saved in N5/Zarr groups.
+    """
+
+    multiscales: Sequence[MultiscaleMetaV2]
+
+    @classmethod
+    def fromDataArrays(
+        cls,
+        arrays: Sequence[DataArray],
+        paths: Sequence[str],
+        name: Optional[str] = None,
+    ):
+        """
+        Generate multiscale metadata from a list or tuple of DataArrays.
+
+        Parameters
+        ----------
+
+        arrays : list or tuple of xarray.DataArray
+            The collection of arrays from which to generate multiscale metadata. These
+            arrays are assumed to share the same `dims` attributes, albeit with varying
+            `coords`.
+
+        paths : list or tuple of str
+            The name on the storage backend for each of the arrays in the multiscale
+            collection.
+
+        name : str, optional
+            The name for the multiresolution collection
+
+        Returns an instance of COSEMGroupMetadataV2
+        -------
+
+        COSEMGroupMetadata
+        """
 
         multiscales = [
             MultiscaleMetaV2(
                 name=name,
-                datasets=_paths,
+                datasets=paths,
             )
         ]
-        return cls(name=name, multiscales=multiscales, paths=_paths)
+        return cls(name=name, multiscales=multiscales, paths=paths)

--- a/src/fibsem_tools/metadata/cosem.py
+++ b/src/fibsem_tools/metadata/cosem.py
@@ -1,10 +1,17 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from pydantic import BaseModel
 from xarray import DataArray
 
+from fibsem_tools.metadata.transform import STTransform
 
-class MultiscaleMeta(BaseModel):
+
+class MultiscaleMetaV1(BaseModel):
+    name: Optional[str]
+    datasets: Sequence[STTransform]
+
+
+class MultiscaleMetaV2(BaseModel):
     name: Optional[str]
     datasets: Sequence[str]
 
@@ -14,7 +21,7 @@ class COSEMGroupMetadata(BaseModel):
     Multiscale metadata used by COSEM for multiscale datasets saved in N5/Zarr groups.
     """
 
-    multiscales: Sequence[MultiscaleMeta]
+    multiscales: Union[Sequence[MultiscaleMetaV2], Sequence[MultiscaleMetaV1]]
 
     @classmethod
     def fromDataArrays(
@@ -54,7 +61,7 @@ class COSEMGroupMetadata(BaseModel):
             _paths = paths
 
         multiscales = [
-            MultiscaleMeta(
+            MultiscaleMetaV2(
                 name=name,
                 datasets=_paths,
             )


### PR DESCRIPTION
This PR restores support for the "old" cosem metadata, that i thoughtlessly removed. Now there's v1 and v2 cosem metadata, they key difference being that for v1, the elements of `multiscales` contain a list of objects with a `path` property and a `transform` property, while in v2 the elements of `multiscales` contain a list of strings instead.