### PR TITLE
feat: overhaul handling of chunks for multiscale GroupSpecs.

### DIFF
--- a/src/fibsem_tools/metadata/cosem.py
+++ b/src/fibsem_tools/metadata/cosem.py
@@ -1,9 +1,20 @@
-from typing import Iterable, Literal, Optional, Sequence, Union
+from typing import Iterable, Literal, Optional, Sequence, Tuple, Union
 
 from pydantic import BaseModel
 from xarray import DataArray
 from pydantic_zarr import GroupSpec, ArraySpec
+from fibsem_tools.io.util import normalize_chunks
 from fibsem_tools.metadata.transform import STTransform
+
+
+def normalize_paths(
+    arrays: Sequence[DataArray], paths: Union[Sequence[str], Literal["auto"]]
+):
+    if paths == "auto":
+        _paths = [f"s{idx}" for idx in range(len(arrays))]
+    else:
+        _paths = paths
+    return _paths
 
 
 class ScaleMetaV1(BaseModel):
@@ -21,7 +32,7 @@ class MultiscaleMetaV2(BaseModel):
     datasets: list[str]
 
 
-class COSEMGroupMetadataV1(BaseModel):
+class CosemGroupMetadataV1(BaseModel):
     """
     Multiscale metadata used by COSEM for multiscale datasets saved in N5/Zarr groups.
     """
@@ -36,47 +47,42 @@ class COSEMGroupMetadataV1(BaseModel):
         name: Optional[str] = None,
     ):
         """
-        Generate multiscale metadata from a list or tuple of DataArrays.
+        Generate multiscale metadata from a sequence of DataArrays.
 
         Parameters
         ----------
 
-        arrays : list or tuple of xarray.DataArray
+        arrays : Sequence[xarray.DataArray]
             The collection of arrays from which to generate multiscale metadata. These
             arrays are assumed to share the same `dims` attributes, albeit with varying
             `coords`.
-
-        paths : Sequence of str or the string literal 'auto', default='auto'
+        paths : Union[Sequence[str], Literal["auto"]]
             The name on the storage backend for each of the arrays in the multiscale
             collection. If 'auto', then names will be automatically generated using the
             format s0, s1, s2, etc
-
-        name : str, optional
+        name : Optional[str]
             The name for the multiresolution collection
 
-
-        Returns an instance of COSEMGroupMetadataV1
+        Returns
         -------
-
-        COSEMGroupMetadata
+        COSEMGroupMetadataV1
         """
 
-        if paths == "auto":
-            paths = [f"s{idx}" for idx in range(len(arrays))]
+        _paths = normalize_paths(arrays, paths)
 
         multiscales = [
             MultiscaleMetaV1(
                 name=name,
                 datasets=[
                     ScaleMetaV1(path=path, transform=STTransform.from_xarray(array=arr))
-                    for path, arr in zip(paths, arrays)
+                    for path, arr in zip(_paths, arrays)
                 ],
             )
         ]
         return cls(name=name, multiscales=multiscales, paths=paths)
 
 
-class COSEMGroupMetadataV2(BaseModel):
+class CosemGroupMetadataV2(BaseModel):
     """
     Multiscale metadata used by COSEM for multiscale datasets saved in N5/Zarr groups.
     """
@@ -91,38 +97,37 @@ class COSEMGroupMetadataV2(BaseModel):
         name: Optional[str] = None,
     ):
         """
-        Generate multiscale metadata from a list or tuple of DataArrays.
+        Generate multiscale metadata from a sequence of DataArrays.
 
         Parameters
         ----------
 
-        arrays : list or tuple of xarray.DataArray
+        arrays : Sequence[xarray.DataArray]
             The collection of arrays from which to generate multiscale metadata. These
             arrays are assumed to share the same `dims` attributes, albeit with varying
             `coords`.
+        paths: Union[Sequence[str], Literal["auto"]] = "auto"
+            The names for each of the arrays in the multiscale
+            collection. If set to "auto", arrays will be named automatically according
+            to the scheme `s0` for the largest array, s1 for second largest, and so on.
+        name : Optional[str], default is None.
+            The name for the multiresolution collection.
 
-        paths : list or tuple of str
-            The name on the storage backend for each of the arrays in the multiscale
-            collection.
-
-        name : str, optional
-            The name for the multiresolution collection
-
-        Returns an instance of COSEMGroupMetadataV2
+        Returns
         -------
+        COSEMGroupMetadataV2
 
-        COSEMGroupMetadata
         """
-        if paths == "auto":
-            paths = [f"s{idx}" for idx in enumerate(arrays)]
+
+        _paths = normalize_paths(arrays, paths)
 
         multiscales = [
             MultiscaleMetaV2(
                 name=name,
-                datasets=paths,
+                datasets=_paths,
             )
         ]
-        return cls(name=name, multiscales=multiscales, paths=paths)
+        return cls(name=name, multiscales=multiscales, paths=_paths)
 
 
 class CosemArrayAttrs(BaseModel):
@@ -135,56 +140,105 @@ class CosemMultiscaleArray(ArraySpec):
     @classmethod
     def from_xarray(cls, array: DataArray, **kwargs):
         attrs = CosemArrayAttrs(transform=STTransform.from_xarray(array))
-        return super().from_array(array, attrs=attrs, **kwargs)
+        return cls.from_array(array, attrs=attrs, **kwargs)
 
 
 class CosemMultiscaleGroupV1(GroupSpec):
-    attrs: COSEMGroupMetadataV1
-    items: dict[str, CosemMultiscaleArray]
+    attrs: CosemGroupMetadataV1
+    members: dict[str, CosemMultiscaleArray]
 
     @classmethod
     def from_xarrays(
         cls,
         arrays: Iterable[DataArray],
+        chunks: Union[Tuple[Tuple[int, ...], ...], Literal["auto"]] = "auto",
         paths: Union[Sequence[str], Literal["auto"]] = "auto",
         name: Optional[str] = None,
         **kwargs,
     ):
+        """
+        Convert a collection of DataArray to a GroupSpec with CosemMultiscaleV1 metadata
 
-        if paths == "auto":
-            paths = [f"s{idx}" for idx in range(len(arrays))]
+        Parameters
+        ----------
 
-        attrs = COSEMGroupMetadataV1.from_xarrays(arrays, paths, name)
+        arrays: Iterable[DataArray]
+            The arrays comprising the multiscale image.
+        chunks : Union[Tuple[Tuple[int, ...], ...], Literal["auto"]], default is "auto"
+            The chunks for the `ArraySpec` instances. Either an explicit collection of
+            chunk sizes, one per array, or the string "auto". If `chunks` is "auto" and
+            the `data` attribute of the arrays is chunked, then each ArraySpec
+            instance will inherit the chunks of the arrays. If the `data` attribute
+            is not chunked, then each `ArraySpec` will have chunks equal to the shape of
+            the source array.
+        paths: Union[Sequence[str], Literal["auto"]] = "auto"
+            The names for each of the arrays in the multiscale
+            collection. If set to "auto", arrays will be named automatically according
+            to the scheme `s0` for the largest array, s1 for second largest, and so on.
+        name: Optional[str], default is None
+            The name for the multiscale collection.
+        **kwargs:
+            Additional keyword arguments that will be passed to the `ArraySpec`
+            constructor.
+        """
+        _paths = normalize_paths(arrays, paths)
+
+        _chunks = normalize_chunks(arrays, chunks)
+        attrs = CosemGroupMetadataV1.from_xarrays(arrays, _paths, name)
 
         array_specs = {
-            k: CosemMultiscaleArray.from_xarray(arr, **kwargs)
-            for k, arr in zip(paths, arrays)
+            key: CosemMultiscaleArray.from_xarray(arr, chunks=cnks, **kwargs)
+            for arr, cnks, key in zip(arrays, _chunks, _paths)
         }
 
-        return cls(attrs=attrs, items=array_specs)
+        return cls(attrs=attrs, members=array_specs)
 
 
 class CosemMultiscaleGroupV2(GroupSpec):
-    attrs: COSEMGroupMetadataV2
-    items: dict[str, ArraySpec[CosemArrayAttrs]]
+    attrs: CosemGroupMetadataV2
+    members: dict[str, ArraySpec[CosemArrayAttrs]]
 
     @classmethod
     def from_xarrays(
         cls,
         arrays: Iterable[DataArray],
+        chunks: Union[Tuple[Tuple[int, ...]], Literal["auto"]] = "auto",
         paths: Union[Sequence[str], Literal["auto"]] = "auto",
         name: Optional[str] = None,
         **kwargs,
     ):
+        """
+        Convert a collection of DataArray to a GroupSpec with CosemMultiscaleV2 metadata
 
-        if paths == "auto":
-            paths = [f"s{idx}" for idx in range(len(arrays))]
+        Parameters
+        ----------
 
-        attrs = COSEMGroupMetadataV2.from_xarrays(arrays, paths, name)
+        arrays: Iterable[DataArray]
+            The arrays comprising the multiscale image.
+        chunks : Union[Tuple[Tuple[int, ...], ...], Literal["auto"]], default is "auto"
+            The chunks for the `ArraySpec` instances. Either an explicit collection of
+            chunk sizes, one per array, or the string "auto". If `chunks` is "auto" and
+            the `data` attribute of the arrays is chunked, then each ArraySpec
+            instance will inherit the chunks of the arrays. If the `data` attribute
+            is not chunked, then each `ArraySpec` will have chunks equal to the shape of
+            the source array.
+        paths: Union[Sequence[str], Literal["auto"]] = "auto"
+            The names for each of the arrays in the multiscale
+            collection.
+        name: Optional[str], default is None
+            The name for the multiscale collection.
+        **kwargs:
+            Additional keyword arguments that will be passed to the `ArraySpec`
+            constructor.
+        """
+
+        _paths = normalize_paths(arrays, paths)
+        _chunks = normalize_chunks(arrays, chunks)
+        attrs = CosemGroupMetadataV2.from_xarrays(arrays, _paths, name)
 
         array_specs = {
-            k: CosemMultiscaleArray.from_xarray(arr, **kwargs)
-            for k, arr in zip(paths, arrays)
+            key: CosemMultiscaleArray.from_xarray(arr, chunks=cnks, **kwargs)
+            for arr, cnks, key in zip(arrays, _chunks, _paths)
         }
 
-        return cls(attrs=attrs, items=array_specs)
+        return cls(attrs=attrs, members=array_specs)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,11 +3,11 @@ import numpy as np
 from xarray import DataArray
 from fibsem_tools.io.xr import stt_from_array
 from fibsem_tools.metadata.cosem import (
-    COSEMGroupMetadataV1,
+    CosemGroupMetadataV1,
     CosemMultiscaleGroupV1,
     CosemMultiscaleGroupV2,
     MultiscaleMetaV1,
-    COSEMGroupMetadataV2,
+    CosemGroupMetadataV2,
     MultiscaleMetaV2,
 )
 from fibsem_tools.metadata.neuroglancer import (
@@ -99,9 +99,9 @@ def test_cosem(version: Literal["v1", "v2"]):
     paths = ("s0", "s1")
     if version == "v1":
 
-        g_meta = COSEMGroupMetadataV1.from_xarrays(multi, paths=paths, name="data")
+        g_meta = CosemGroupMetadataV1.from_xarrays(multi, paths=paths, name="data")
 
-        assert g_meta == COSEMGroupMetadataV1(
+        assert g_meta == CosemGroupMetadataV1(
             multiscales=[
                 MultiscaleMetaV1(
                     name="data",
@@ -114,13 +114,13 @@ def test_cosem(version: Literal["v1", "v2"]):
         )
         spec = CosemMultiscaleGroupV1.from_xarrays(multi, name="data")
         assert spec.attrs == g_meta
-        assert tuple(spec.items.keys()) == paths
+        assert tuple(spec.members.keys()) == paths
 
     else:
-        g_meta = COSEMGroupMetadataV2.from_xarrays(multi, paths=paths, name="data")
-        assert g_meta == COSEMGroupMetadataV2(
+        g_meta = CosemGroupMetadataV2.from_xarrays(multi, paths=paths, name="data")
+        assert g_meta == CosemGroupMetadataV2(
             multiscales=[MultiscaleMetaV2(name="data", datasets=paths)]
         )
         spec = CosemMultiscaleGroupV2.from_xarrays(multi, name="data")
         assert spec.attrs == g_meta
-        assert tuple(spec.items.keys()) == paths
+        assert tuple(spec.members.keys()) == paths

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -51,6 +51,5 @@ def test_multiscale_storage(temp_zarr, metadata_types: Tuple[str, ...]):
 
     array_urls = [f"{temp_zarr}/{ap}" for ap in array_paths]
     da.compute(store_blocks(multi, [access(a_url, mode="a") for a_url in array_urls]))
-
     assert dict(group.attrs) == g_spec.attrs
     assert all(read(a).chunks == chunks for a in array_urls)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,18 @@
+import pytest
+import dask.array as da
+from xarray import DataArray
+from fibsem_tools.io.util import normalize_chunks
+
+
+@pytest.mark.parametrize("chunks", ("auto", (3, 3, 3), ((3, 3, 3), (3, 3, 3))))
+def test_normalize_chunks(chunks):
+    arrays = DataArray(da.zeros((10, 10, 10), chunks=(4, 4, 4))), DataArray(
+        da.zeros((5, 5, 5), chunks=(2, 2, 2))
+    )
+    observed = normalize_chunks(arrays, chunks)
+    if chunks == "auto":
+        assert observed == (arrays[0].chunks, arrays[1].chunks)
+    elif isinstance(chunks[0], int):
+        assert observed == (chunks,) * len(arrays)
+    else:
+        assert observed == chunks

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -105,7 +105,7 @@ def test_read_datatree(temp_zarr, attrs, coords, use_dask, name):
     g_spec = multiscale_group(
         arrays=tuple(data.values()),
         array_paths=tuple(data.keys()),
-        chunks=(64, 64, 64),
+        chunks=((64, 64, 64),) * len(data),
         metadata_types=["cosem"],
     )
     g_spec.attrs.update(**_attrs)


### PR DESCRIPTION
For multiscale metadata `.from_xarrays` methods, `chunks` can now be the string "auto", a tuple of ints, or an explicit tuple of tuples of ints.