### PR TITLE
Dependencies

### DIFF
--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install poetry=1.4.1
+        pip install poetry==1.4.1
     - name: Build and publish
       env:
         PYPI_USERNAME: __token__

--- a/src/fibsem_tools/io/n5/core.py
+++ b/src/fibsem_tools/io/n5/core.py
@@ -181,7 +181,7 @@ def create_datatree(
             use_dask=use_dask,
             attrs=None,
             name="data",
-        )
+        ).to_dataset()
         for name, array in element.arrays()
     }
     root_attrs = element.attrs.asdict() if attrs is None else attrs

--- a/src/fibsem_tools/io/zarr/core.py
+++ b/src/fibsem_tools/io/zarr/core.py
@@ -338,7 +338,7 @@ def create_datatree(
             use_dask=use_dask,
             attrs=None,
             name="data",
-        )
+        ).to_dataset()
         for name, array in element.arrays()
     }
     root_attrs = element.attrs.asdict() if attrs is None else attrs

--- a/tests/io/test_zarr.py
+++ b/tests/io/test_zarr.py
@@ -76,7 +76,8 @@ def test_read_xarray(tmp_zarr: str) -> None:
         zgroup[key] = value.data
         zgroup[key].attrs["transform"] = stt_from_array(value).model_dump()
 
-    tree_expected = DataTree.from_dict(data, name=path)
+    nodes = {k : v.to_dataset() for k, v in data.items()}    
+    tree_expected = DataTree.from_dict(nodes, name=path)
     assert_equal(to_xarray(zgroup["s0"]), data["s0"])
     assert_equal(to_xarray(zgroup["s1"]), data["s1"])
     assert tree_expected.equals(to_xarray(zgroup))
@@ -151,7 +152,7 @@ def test_read_datatree(
             access(tmp_zarr, os.path.join(path, k), mode="r"),
             coords=data[k].coords,
             name="data",
-        )
+        ).to_dataset()
         for k in data
     }
 


### PR DESCRIPTION
xarray-datatree was merged with xarray as xarray.DataTree. The nodes in data tree could now be either xarray.DataSet or xarray.DataTree. create_datatree() method and tests were modified to avoid type error issues. 
